### PR TITLE
Icon settings for Plone 5

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -33,6 +33,8 @@ Changelog
 - Register resource directory to enable csscompilation entry in registry.xml
   [davilima6]
 
+- Fixed image vocabulary and condition for showing icons in drop down menu.
+  [espenmn]
 
 2.3.1 (2012-07-26)
 ------------------

--- a/src/webcouturier/dropdownmenu/browser/dropdown_recurse.pt
+++ b/src/webcouturier/dropdownmenu/browser/dropdown_recurse.pt
@@ -18,7 +18,6 @@
                 item_remote_url node/getRemoteUrl;
                 use_remote_url  node/useRemoteUrl | nothing;
                 item_type       node/portal_type;
-                item_icon       nocall:node/item_icon;
                 my_item         node/item;
                 absolute_url    nocall:python:my_item.getObject().absolute_url;
                 normalizeString nocall: context/plone_utils/normalizeString;"

--- a/src/webcouturier/dropdownmenu/browser/dropdown_recurse.pt
+++ b/src/webcouturier/dropdownmenu/browser/dropdown_recurse.pt
@@ -34,11 +34,12 @@
                            title node/Description;
                            class python:item_clickable and item_class or item_class + ' noClick'">
 
-            <span tal:content="node/Title" class="submenu_title">Selected Item Title</span>
             <img src="" alt="" class="subnmenu_image"
-                 tal:define="has_icon exists:python:my_item.getObject().getImage().icon"
-                 tal:attributes="src string:${absolute_url}/image_${enable_thumbs}"
+                 tal:define="has_icon exists:python:my_item.getObject().image"
+                 tal:attributes="src string:${absolute_url}/@@images/image/${enable_thumbs}"
                   tal:condition="python:has_icon and enable_thumbs!='none'" />
+
+            <span tal:content="node/Title" class="submenu_title">Selected Item Title</span>
 
             <span tal:content="node/Description" class="submenu_description"
                   tal:condition="enable_desc">Selected Item Description</span>

--- a/src/webcouturier/dropdownmenu/browser/dropdown_sections.pt
+++ b/src/webcouturier/dropdownmenu/browser/dropdown_sections.pt
@@ -27,7 +27,7 @@
                               subitems python:view.getTabObject(tabUrl = tab['url'], tabPath = tab.get('path'))"
                   tal:attributes="id string:portaltab-${tid};
                                   class python:selected_tab==tid and 'selected' or nothing">
-                  <a href=""
+                  <a href="" class="tab/children"
                      tal:content="tab/name"
                      tal:attributes="href tab/url;
                                      title tab/description|nothing;

--- a/src/webcouturier/dropdownmenu/browser/static/dropdown.less
+++ b/src/webcouturier/dropdownmenu/browser/static/dropdown.less
@@ -46,6 +46,10 @@
   }
 }
 
+.submenu_description {
+	display: block;
+}
+
 @media (max-width: 768px) {
   .plone-navbar-nav li {
     .submenu {

--- a/src/webcouturier/dropdownmenu/browser/static/webcouturier.dropdownmenu-compiled.css
+++ b/src/webcouturier/dropdownmenu/browser/static/webcouturier.dropdownmenu-compiled.css
@@ -50,6 +50,10 @@
   top: 0;
   left: 100%;
 }
+
+.submenu_description {
+	display: block;
+}
 @media (max-width: 768px) {
   /* line 52, http://localhost:8080/Plone/++plone++dropdown/dropdown.less */
   .plone-navbar-nav li .submenu {

--- a/src/webcouturier/dropdownmenu/configure.zcml
+++ b/src/webcouturier/dropdownmenu/configure.zcml
@@ -30,4 +30,7 @@
         name="webcouturier.dropdownmenu.SizeVocabulary"
         />
 
+
+
+
 </configure>

--- a/src/webcouturier/dropdownmenu/vocabularies.py
+++ b/src/webcouturier/dropdownmenu/vocabularies.py
@@ -23,6 +23,7 @@ def SizeVocabulary(context):
             SimpleTerm('mini', 'mini', u'Mini'),
             SimpleTerm('preview', 'preview', u'Preview'),
             SimpleTerm('icon', 'icon', u'Icon'),
+            SimpleTerm('none', 'none', u'none'),
         ]
         
     try:
@@ -35,6 +36,8 @@ def SizeVocabulary(context):
             sizes = portal_properties.imaging_properties.getProperty('allowed_sizes')
 
     if sizes:
+        if not 'none' in sizes:
+            sizes += ('none',)
         terms = [ SimpleTerm(value=format_size(pair), token=format_size(pair), title=pair) for pair in sizes ]
       
     return SimpleVocabulary(terms)

--- a/src/webcouturier/dropdownmenu/vocabularies.py
+++ b/src/webcouturier/dropdownmenu/vocabularies.py
@@ -2,7 +2,9 @@
 from zope.schema.vocabulary import SimpleTerm, SimpleVocabulary
 from Products.CMFCore.utils import getToolByName
 from plone import api
-#from zope.schema.interfaces import IVocabularyFactory
+
+from zope.schema.interfaces import IVocabularyFactory
+from zope.interface import directlyProvides
 
 from webcouturier.dropdownmenu import msg_fact as _
 
@@ -18,13 +20,8 @@ def format_size(size):
 def SizeVocabulary(context):
     site = getSite()
     #default vocabulary if everything else fails
-    sizes = None
-    terms = [
-            SimpleTerm('mini', 'mini', u'Mini'),
-            SimpleTerm('preview', 'preview', u'Preview'),
-            SimpleTerm('icon', 'icon', u'Icon'),
-            SimpleTerm('none', 'none', u'none'),
-        ]
+    sizes = []
+    terms = []
         
     try:
         #Plone 5
@@ -36,10 +33,17 @@ def SizeVocabulary(context):
             sizes = portal_properties.imaging_properties.getProperty('allowed_sizes')
 
     if sizes:
-        if not 'none' in sizes:
-            sizes += ('none',)
         terms = [ SimpleTerm(value=format_size(pair), token=format_size(pair), title=pair) for pair in sizes ]
+        
+    if not 'none' in terms:    
+        terms.append(SimpleVocabulary.createTerm('none', 'none', u'None'))
       
     return SimpleVocabulary(terms)
     
+ 
+  
+ 
+ 
+
+
  


### PR DESCRIPTION
Fixed icon vocabulary for plone 5. Also fixed conditions in template and moved image before the title.
Probably: the settings should default to not showing image or description.