### PR TITLE
fix MANIFEST path so zcml is included

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include docs/*.txt
-recursive-include collective *.css *.js *.pdf *.png *.po *.pot *.pt *.txt *.xml *.zcml
+recursive-include src/webcouturier/* *.css *.js *.pdf *.png *.po *.pot *.pt *.txt *.xml *.zcml
 global-exclude *.pyc *~


### PR DESCRIPTION
It looks like this MANIFEST was copied from something that had collective in the path. I have changed the recursive-include so the zcml is picked up when building egg.