### PR TITLE
Fix the ``Home`` tab always set active.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 3.0.2 (unreleased)
 ------------------
 
+- To set global section active tab, use ``selected_portal_tab`` instead simple url comparison.
+  Fixes the ``Home`` tab always set active.
+  Fixes: #31.
+  [thet]
+
 - Fix AttributeError during upgrade. 
   [abosio]
 

--- a/src/webcouturier/dropdownmenu/browser/dropdown_sections.pt
+++ b/src/webcouturier/dropdownmenu/browser/dropdown_sections.pt
@@ -31,7 +31,7 @@
                               class_clickable python:' noClick' if not view.enable_parent_clickable and subitems else '';
                               class_position  python:'menu-position-{0}'.format(repeat.tab.number);
                               class_children  python:' hasDropDown dropdown' if subitems else '';
-                              class_selected  python:' selected active' if href in context.absolute_url() else '';
+                              class_selected  python:' selected active' if selected_tab==tid else '';
                               review_state    python:' state-' + tab.get('review_state') if tab.get('review_state', None) else None"
                   id="portaltab-${tid}"
                   class="${class_position}${class_children}${class_selected}">


### PR DESCRIPTION
To set global section active tab, use ``selected_portal_tab`` instead simple url comparison.
Fixes: #31.