### PR TITLE
fix unwanted space in top level items when you have submenus

### DIFF
--- a/src/webcouturier/dropdownmenu/browser/dropdown_sections.pt
+++ b/src/webcouturier/dropdownmenu/browser/dropdown_sections.pt
@@ -43,7 +43,7 @@
                       class="dropdown-toggle${review_state}${class_clickable}"
                       role="button"
                       aria-haspopup="true"
-                      aria-expanded="false">${tab/name} <span class="caret"></span></a>
+                      aria-expanded="false">${tab/name}<span class="caret"></span></a>
                   <a
                       tal:condition="not:subitems"
                       href="${href}"


### PR DESCRIPTION
When there are submenus there is a down arrow caret. e.g. ```${tab/name} <span class="caret"></span>```. Sometimes your design doesn't have this caret so you remove it. But there is still this extra space thats inserted which is harder to remove using css or diazo. This change removes that space.